### PR TITLE
Added ability to create a new proposal

### DIFF
--- a/app/mod_auth/views.py
+++ b/app/mod_auth/views.py
@@ -13,7 +13,7 @@ auth = Blueprint('auth', __name__)
 @auth.route('/login', methods=['GET', 'POST'])
 def login():
 	if current_user.is_authenticated():
-		return redirect(url_for('proposals.make'))
+		return redirect(url_for('schools.home'))
 	form = LoginForm(username=request.args.get('username', None), next=request.args.get('next', None))
 	if form.validate_on_submit():
 		user, authenticated = authenticate_user(form.username.data, form.password.data)

--- a/app/mod_proposal/forms.py
+++ b/app/mod_proposal/forms.py
@@ -35,7 +35,7 @@ AddProposalForm = model_form( Proposal,
 		'events',
 		'discussions',
 		'tags'))
-submit_add = SubmitField('Propose!')
+submit_add = SubmitField('Propose')
 AddProposalForm.submit = submit_add
 
 

--- a/app/mod_proposal/models.py
+++ b/app/mod_proposal/models.py
@@ -38,7 +38,7 @@ class BaseProposal(db.Document, InterestedMixin):
 
 	title = db.StringField(max_length=255)
 	# A copy of the original description is kept
-	description = db.StringField()
+	description = db.StringField(max_length=1000)
 	edited_description = db.StringField()
 	# School the proposal was made to
 	schools = db.ListField(db.ReferenceField(School, reverse_delete_rule = NULLIFY))

--- a/app/mod_proposal/views.py
+++ b/app/mod_proposal/views.py
@@ -74,12 +74,7 @@ def detail(id):
 @proposals.route('/make', methods=['GET', 'POST'])
 @login_required
 def make():
-	""" Make a proposal route """
-	schools = g.all_schools
-	if g.is_default_school and len(schools)>0:
-		return render_template('proposal/make_choose_school.html',
-			title=_('Which school?'),
-			schools=[school for school in schools if not school==g.default_school])
+	""" Make a proposal """
 	form = AddProposalForm()
 	if form.validate_on_submit():
 		p = Proposal(schools=[g.school,], proposer=current_user._get_current_object())

--- a/app/mod_school/models.py
+++ b/app/mod_school/models.py
@@ -6,9 +6,6 @@ from app.database import db
 
 class School(db.Document):
 	name = db.StringField(max_length=64, required=True)
-	title = db.StringField(max_length=255)
-	about = db.StringField()
-	styles = db.StringField()
 
 	def __str__(self):
 		return self.name

--- a/app/mod_school/views.py
+++ b/app/mod_school/views.py
@@ -1,11 +1,25 @@
-from flask import Blueprint, g, render_template, flash, redirect, request, url_for
+from flask import Blueprint, g, render_template, flash, redirect, request, url_for, abort
 from flask.ext.login import login_required, login_user, logout_user, current_user
 from flask.ext.babel import gettext as _
 
+from .models import School
+from .forms import SchoolForm
 
 schools = Blueprint('schools', __name__)
-
 
 @schools.route('/', methods=['GET'])
 def home():
 	return render_template('school/home.html', title='Home', school=g.school)
+
+@schools.route('/schools/add', methods=['GET', 'POST'])
+def add_school():
+    if not current_user.is_admin():
+        abort(403)
+    
+    form = SchoolForm()
+    if form.validate_on_submit():		
+        s = School()
+        form.populate_obj(s)
+        s.save()
+        return redirect(url_for('schools.add_school'))
+    return render_template('school/add_school.html', form=form)

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -1,4 +1,4 @@
-{% from "macros/_nav.html" import schools_nav_dropdown %}
+﻿{% from "macros/_nav.html" import schools_nav_dropdown %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
@@ -42,14 +42,18 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" href="{{ url_for_school('schools.home') }}">THE PUBLIC SCHOOL</a>
+                    <a class="navbar-brand" href="{{ url_for_school('schools.home') }}">Elective</a>
                 </div>
                 <div id="navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">
-                        {{ schools_nav_dropdown() }}
+                        <!--{{ schools_nav_dropdown() }}-->
                         <li><a href='{{ url_for('proposals.list') }}'>Proposals</a></li>
                         <li><a href='{{ url_for('events.list') }}'>Classes</a></li>
-                        <li><a href='{{ url_for('proposals.make') }}'>Propose a class!</a></li>
+                        <li><a href='{{ url_for('proposals.make') }}'>Propose a class</a></li>
+                        {% if current_user.is_admin() %}
+                        {# Hidden for now. Removing the concept on schools for this prototype. #}
+                        <!--<li><a href="{{ url_for('schools.add_school')}}">Add a school</a></li>-->
+                        {% endif %}
                     </ul>
                     <ul class="nav navbar-nav navbar-right">
                     {% if current_user.is_authenticated() %}

--- a/app/templates/proposal/make.html
+++ b/app/templates/proposal/make.html
@@ -7,7 +7,7 @@
 {% block body_classes %}{% endblock %}
 
 {% block body %}
-<h2>Propose</h2>
+<h2>Propose a class</h2>
 <div>
     {{ render_form(url_for('proposals.make'), form)}}
 </div>
@@ -21,10 +21,13 @@
 {% block extra_js %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
 <script>
-$(function () {
-	$('#tags').select2({
-		tags: true
-	});
-});
+    $(document).ready(function () {
+	    $('#tags').select2({
+		    tags: true
+	    });
+	    var parent = $('#description').parent();
+	    $('#description').remove();
+	    parent.prepend("<textarea class=\"form-control\" id=\"description\" name=\"description\" rows=\"4\"></textarea><span class=\"help-inline\"></span>");
+    });
 </script>    
 {% endblock %}

--- a/app/templates/user/create.html
+++ b/app/templates/user/create.html
@@ -7,7 +7,7 @@
 {% block body_classes %}{% endblock %}
 
 {% block body %}
-<h2>Sign up for The Public School</h2>
+<h2>Sign up for Elective</h2>
 <div>
     {{ render_form(url_for('users.create'), form)}}
 </div>


### PR DESCRIPTION
- Added functionality to add a school if logged in as an admin.
- Changed all instances of "The Public School" to "Elective" to match the new branding.
- Hiding "Add a school" button on navbar. Decided to hide school creation functionality due to removing the concept of schools for this iteration.
- Code was previously set to redirect to proposal creation page if sent to the login page while already logged in. This didn't make sense to me, so I changed the redirection to the home page.
- "Propose a class" navbar button now properly gives a user a form to create a proposal. Validation was added to prevent an empty proposal title and description. Empty tags are allowed.
