### PR TITLE
Adding Google Translate to the site

### DIFF
--- a/app/mod_discussion/forms.py
+++ b/app/mod_discussion/forms.py
@@ -47,7 +47,7 @@ AddCommentForm = model_form( Comment,
 		'updated',
 		'created',
 		'creator',
-		'discussion'))
+		'discussion', 'is_deleted'))
 submit_add = SubmitField('Comment')
 AddCommentForm.submit = submit_add
 
@@ -58,6 +58,6 @@ EditCommentForm = model_form( Comment,
 		'updated',
 		'created',
 		'creator',
-		'discussion'))
+		'discussion', 'is_deleted'))
 submit_edit = SubmitField('Edit Comment')
 EditCommentForm.submit = submit_edit

--- a/app/mod_discussion/models.py
+++ b/app/mod_discussion/models.py
@@ -20,6 +20,7 @@ class Comment(db.Document):
 	discussion = db.GenericReferenceField()
 	# The actual content of the comment
 	text = db.StringField(max_length=5000, required=True)
+	is_deleted = db.BooleanField(default=False)
 	
 	def edit_comment(self, newText):
 		self.text = newText

--- a/app/mod_event/views.py
+++ b/app/mod_event/views.py
@@ -105,3 +105,8 @@ def delete(id):
 	
 	e.delete()
 	return json.dumps({'success':True}), 200, {'ContentType':'application/json'}
+
+@events.route('/places/<id>', methods=['GET'])
+def get_place(id):
+	pl = Place.objects.get_or_404(id=id)
+	return pl.name

--- a/app/mod_user/models.py
+++ b/app/mod_user/models.py
@@ -22,6 +22,10 @@ class User(db.Document, UserMixin):
 	# School/s the user is following
 	schools = db.ListField(db.ReferenceField(School, reverse_delete_rule = NULLIFY))
 
+	available_weekday_morning = db.BooleanField(default=False)
+	available_weekday_night = db.BooleanField(default=False)
+	available_weekend_morning = db.BooleanField(default=False)
+	available_weekend_night = db.BooleanField(default=False)
 
 	# following which schools? (list of schools)
 	# committee memberships (list)

--- a/app/templates/discussion/detail.html
+++ b/app/templates/discussion/detail.html
@@ -30,20 +30,25 @@
             {% if comments %}
             {% for comment in comments %}
                 <p style="margin-bottom:0px;display:inline-block">{{ comment.creator.display_name }} commented on {{ comment.created | datetime }}</p>
-                {% set can_edit = can_edit_comment(comment) %}
-                {% if can_edit %}
-                <a style="display:inline-block" class="btn btn-sm btn-primary" href="{{ url_for('discussions.edit_comment', discussion_id=discussion.id, comment_id=comment.id, proposal_id=proposal_id) }}"><span class="glyphicon glyphicon-edit"></span> Edit Comment</a>
+                {% if current_user.id==comment.creator.id or current_user.is_admin()%}
+                    <a style="display:inline-block;margin-right:8px" class="btn btn-sm btn-primary" href="{{ url_for('discussions.edit_comment', discussion_id=discussion.id, comment_id=comment.id, proposal_id=proposal_id) }}"><span class="glyphicon glyphicon-edit"></span> Edit Comment</a>
+                    {% if not comment.is_deleted %}
+                        <a style="display:inline-block" class="btn btn-sm btn-danger" href="{{ url_for('discussions.delete_comment', discussion_id=discussion.id, comment_id=comment.id, proposal_id=proposal_id) }}"><span class="glyphicon glyphicon-trash"></span> Delete Comment</a>
+                    {% endif %}
                 {% endif %}
                 <div style="margin-left:20px">
-                    <p>{{ comment.text }}</p>
+                    {% if not comment.is_deleted %}
+                        <p>{{ comment.text }}</p>
+                    {% else %}
+                        <p><em>This comment has been deleted.</em></p>
+                    {% endif %}
                 </div>
             {% endfor %}
             {% endif %}
         </dd>
         
     </dl>
-</div>
-	
+</div>	
 
 <div class="json-hide">
     <h3>Discussion JSON</h3>

--- a/app/templates/event/detail.html
+++ b/app/templates/event/detail.html
@@ -72,7 +72,7 @@
         <!--<dt>Created by:</dt>
         <dd>{{ event.creator.display_name }}</dd>-->
 
-        <dt>Teacher:</dt>
+        <dt>Teacher / Convener:</dt>
         <dd>{{ event.teacher }}</dd>
 
         <dt>Number of attending users:</dt>
@@ -168,6 +168,7 @@
             .success(function (data) {
                 if (data.anon === true) {
                     window.location.href = '/login?interested_user=anon';
+                    return;
                 }
 
                 // Counter within the interested widget

--- a/app/templates/event/edit.html
+++ b/app/templates/event/edit.html
@@ -39,6 +39,20 @@ $(function () {
 		'extraFormats': [ 'YYYY-MM-DD HH:mm:ss' ]
 	});
 
+    // Fix for IE Bug: Select box is all blank! 
+	$('#places > option').each(function () {
+	    var placeID = $(this).val();
+	    var that = $(this);
+
+	    $.ajax({
+	        url: '/events/places/' + placeID,
+	        type: 'GET',
+	        success: function (data) {
+	            that.text(data);
+	        }
+	    });
+	});
+
     // Sort options alphabetically: http://stackoverflow.com/a/26232541/5573838
 	var sel = $('#places');
 	var opts_list = sel.find('option');

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -177,11 +177,9 @@
 <body id="body" class='tps-{{ g.school.name }} {% block body_classes %}{% endblock %}' data-user-id="{{ current_user.id }}">
     {% block topbar %}
     <div class="container-fluid" style="margin-top: -20px;">
-        <nav class="navbar navbar-default row">
+        <nav class="navbar navbar-default row" style="margin-bottom:5px">
             <div class="container-fluid" style="background-color: rgb(255, 204, 0);">
-                {% if current_user.username %}
-                <label style="position:absolute;margin-top:60px;margin-left:15px;">Welcome, {{ current_user.username }}!</label>
-                {% endif %}
+                
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
                         <span class="sr-only">Toggle navigation</span>
@@ -215,10 +213,20 @@
                         {% endif %}
                     </ul>
                 </div>
+                {% if current_user.username %}
+                <label style="position:absolute;margin-left:15px;margin-top: -20px;">Welcome, {{ current_user.username }}!</label>
+                {% endif %}
             </div>
             {% block secondary %}
             {% endblock %}
         </nav>
+        <div id="google_translate_element" class="pull-right" style="margin-bottom:5px"></div>
+        <script type="text/javascript">
+            function googleTranslateElementInit() {
+                new google.translate.TranslateElement({ pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE }, 'google_translate_element');
+            }
+        </script>
+        <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
         </div>
     {% endblock %}    
 

--- a/app/templates/proposal/detail.html
+++ b/app/templates/proposal/detail.html
@@ -110,6 +110,32 @@
             </dd>            
 
             {% if current_user.is_admin() %}
+            <dt>Registered user availability: <span class="label label-primary">Admin Only</span></dt>
+            <dd>
+                {% set count_wdm = [] %}
+                {% set count_wdn = [] %}
+                {% set count_wkm = [] %}
+                {% set count_wkn = [] %}
+                {% for interested in proposal.interested %}
+                {% if interested.user.available_weekday_morning == True %}
+                {% if count_wdm.append('1') %}{% endif %}
+                {% endif %}
+
+                {% if interested.user.available_weekday_night == True %}
+                {% if count_wdn.append('1') %}{% endif %}
+                {% endif %}
+
+                {% if interested.user.available_weekend_morning == True %}
+                {% if count_wkm.append('1') %}{% endif %}
+                {% endif %}
+
+                {% if interested.user.available_weekend_night == True %}
+                {% if count_wkn.append('1') %}{% endif %}
+                {% endif %}
+                {% endfor %}
+                Weekday Morning ({{count_wdm|length}}), Weekday Night ({{count_wdn|length}}), Weekend Morning ({{count_wkm|length}}), Weekend Night ({{count_wkn|length}})
+            </dd>
+
             <dt>Registered user emails: <span class="label label-primary">Admin Only</span></dt>
             <dd>                                
                 {% for i in proposal.interested %}
@@ -126,6 +152,8 @@
             <dd>
                 {{ proposal.anon_emails | join (', ')}}
             </dd>  
+
+  
             {% endif %}
 
 

--- a/app/templates/proposal/organize.html
+++ b/app/templates/proposal/organize.html
@@ -41,6 +41,20 @@ $(function () {
 		'extraFormats': [ 'YYYY-MM-DD HH:mm:ss' ]
 	});
 
+    // Fix for IE Bug: Select box is all blank! 
+	$('#places > option').each(function () {
+	    var placeID = $(this).val();
+	    var that = $(this);
+
+	    $.ajax({
+	        url: '/events/places/' + placeID,
+	        type: 'GET',
+	        success: function (data) {
+	            that.text(data);
+	        }
+	    });
+	});
+
     // Sort options alphabetically: http://stackoverflow.com/a/26232541/5573838
 	var sel = $('#places');
 	var opts_list = sel.find('option');
@@ -58,6 +72,9 @@ $(function () {
     // Set title and description of class to be the same as the proposal. The user may change it if they want to.
 	$('#title').val("{{ proposal_title | escapejs }}");
 	$('#description').val("{{ proposal_description | escapejs }}");
+
+    // Changes a label from "Teacher" to "Teacher / Convener". Should be done on the back end where the form comes in, but time constraints are tight.
+	$('[for="teacher"]').text("Teacher / Convener");
 
 	//$('#places').select2({
 	//	tags: true

--- a/app/templates/user/create.html
+++ b/app/templates/user/create.html
@@ -24,6 +24,12 @@
 {% block extra_js %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
 <script>
-$('#schools').select2();
+    $('#schools').select2();
+
+    $(document).ready(function () {
+        var firstCheckbox = $('[class="checkbox"]:first');
+        var availabilityLabel = '<p><b>Availability for classes. This will allow us to schedule classes based on the majority\'s availability.</b></p>';
+        firstCheckbox.html(availabilityLabel + firstCheckbox.html());
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
… not properly remove the ending comma.
- Changed the terminology of being "interested" on the class side to "attendance".
- Added list of registered user emails on class details page.
- Defined clearer rules for manipulating proposals and classes. Edit proposal, organize proposal, and delete proposal are always visible and executable to admins. The proposer is always able to see the edit proposal button, but can only execute an edit if there are no other interested users besides him/herself. A message box appears if a proposer attempts to edit a proposal with interested users. Only admins can edit and delete classes.
- Added sign up button to sign in page
- Changed "Teacher" to "Teacher / Convener" on organize page and class details page.
- Google translate button implemented.
- Gave privilege to admins to edit any comments.
- Implemented the ability to delete comments. Admins can delete any comments; comment creators can delete their own comments. Comments are not actually deleted, but stated that they are in the front end. This is to maintain the old comment text in the database, and to not confuse the flow of comments by explaining to the users what happened to a deleted comment.
- Fixed a bug in IE where select boxes would appear all blank. Everything else seems to work in Internet Explorer.
- Fixed an issue where the welcome user label would be shifted to the right on Mozilla Firefox only.
- Added option for users to specify availability. Admins see the display on specific proposals.
